### PR TITLE
DM-44738: Initial draft

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ jobs:
     uses: lsst-sqre/rubin-sphinx-technote-workflows/.github/workflows/ci.yaml@v1
     with:
       handle: sqr-086
+      apt_packages: 'graphviz'
     secrets:
       ltd_username: ${{ secrets.LTD_USERNAME }}
       ltd_password: ${{ secrets.LTD_PASSWORD }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+index.md

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ With this standards-based approach, clients like the Portal can show description
 
 You can clone this repository and build the technote locally if your system has Python 3.11 or later:
 
-.. code-block:: bash
-
 ```sh
 git clone https://github.com/lsst-sqre/sqr-086
 cd sqr-086

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 [![Website](https://img.shields.io/badge/sqr--086-lsst.io-brightgreen.svg)](https://sqr-086.lsst.io)
 [![CI](https://github.com/lsst-sqre/sqr-086/actions/workflows/ci.yaml/badge.svg)](https://github.com/lsst-sqre/sqr-086/actions/workflows/ci.yaml)
 
-# A data documentation deep linking service with IVOA DataLink
+# Deep linking to data documentation with IVOA DataLink
 
 ## SQR-086
 
-LSST users retrieve data through VO services, either directly or through clients like the Rubin Science Platform's Portal. IVOA provides a DataLink specification that allows datasets to express relationships with other resources, such as related datasets. This technote outlines a method for using DataLink to also link into the documentation for data, both at the table and column level. With this standards-based approach, clients like the Portal can show descriptions and links to documentation from their user infraces.
+When presenting LSST data through VO services, we want to annotate that data with links to documentation, such as the table and column descriptions in data release documentation sites hosted on `lsst.io`.
+This technote describes a system where we implement a linking service that uses the IVOA DataLink standard to provide links to table and column documentation.
+This link service, which resides in the Rubin Science Platform (RSP), is called by TAP schema queries.
+In turn, the link service queries Ook, Rubin Observatory's documentation metadata service that indexes the link inventories of documentation sites.
+These link inventories are prepared and included with Sphinx documentation builds using Sphinx extensions provided by the Documenteer package.
+With this standards-based approach, clients like the Portal can show descriptions and links to documentation from their user interfaces.
 
 **Links:**
 
@@ -13,7 +18,6 @@ LSST users retrieve data through VO services, either directly or through clients
 - Alternative editions: https://sqr-086.lsst.io/v
 - GitHub repository: https://github.com/lsst-sqre/sqr-086
 - Build system: https://github.com/lsst-sqre/sqr-086/actions/
-
 
 ## Build this technical note
 

--- a/index.md
+++ b/index.md
@@ -6,10 +6,10 @@ This technote describes a system where we implement a linking service that uses 
 This link service, which resides in the Rubin Science Platform (RSP), is called by TAP schema queries.
 In turn, the link service queries Ook, Rubin Observatory's documentation metadata service that indexes the link inventories of documentation sites.
 These link inventories are prepared and included with Sphinx documentation builds using Sphinx extensions provided by the Documenteer package.
-With this standards-based approach, clients like the Portal can show descriptions and links to documentation from their user interfaces.
+With this standards-based approach, clients like the Portal can show descriptions and links to data documentation from their user interfaces.
 ```
 
-## High level overview
+## High-level overview
 
 This overview traces the system's component architecture from the end-user's perspective through to the intention of the documentation author.
 
@@ -19,16 +19,16 @@ This overview traces the system's component architecture from the end-user's per
 
 Consider a Rubin Science Platform user who is working in the Portal to query and view LSST data.[^agnostic]
 The Firefly-based Portal shows information about tables and columns by making queries against the [TAP][tap] schema.
-The LSST TAP schemas are annotated with [DataLink][datalink] service descriptors points to a link service, also hosted in the RSP, that provides links to entities like tables and columns in an LSST data release.
+The LSST TAP schemas are annotated with [DataLink][datalink] service descriptors pointing to link endpoints, also hosted in the RSP, that provide URLs to related entities like table and column descriptions in LSST data release documentation.
 These service descriptors are added to the TAP schema through definition files in [sdm_schemas][sdm_schemas], which is managed through [Felis][felis].
-The service descriptors specify access URLs, including query parameters, to a link endpoint provided by another RSP service.
-In the RSP, the [datalinker][datalinker] Python project provides a link service that can be extended for this application.
-The link endpoint, through the datalinker service, operates in the RSP so that it can be aware of what data is available in that RSP, and can make any last-mile transformations to the links, including adding RSP-specific links.
+The service descriptors specify access URLs, including query parameters, to link endpoints provided by another RSP service.
+In the RSP, the [datalinker][datalinker] Python application provides a link service that can be extended for this application.
+The link endpoints, through the datalinker service, operate in the RSP so that they can be aware of what data is available in that RSP and can make any last-mile transformations to the links, including adding RSP-specific links.
 See [](#datalinker-service).
 
-[^agnostic]: Although we use the Portal as the example, and also as the driving use case, by adopting the IVOA DataLink standard, other VO clients can also get documentation links.
+[^agnostic]: Although we use the Portal as the example, and also as the driving use case, by adopting the IVOA DataLink standard other VO clients can also get documentation links.
 
-Most documentation links will be provided through documentation sites hosted outside the Rubin Science Platform on `lsst.io`, which is managed by the LSST the Docs ({sqr}`006`) static documentation site platform.
+Most documentation links will point to documentation sites hosted outside the Rubin Science Platform on `lsst.io`, which is managed by the LSST the Docs ({sqr}`006`) static documentation site platform.
 So that the link service in the RSP doesn't have to be aware in detail of these documentation sites, and also so that other data facilities can mix in other documentation sources for their RSP deployments, we propose that the link service also acts as a proxy to a link provider that lives closer to the documentation domain.
 
 The [Ook][ook] documentation librarian service, which is hosted in the Roundtable internal services Kubernetes cluster, already indexes Rubin documentation sites.
@@ -52,7 +52,7 @@ To accomplish this, we will build upon the core Sphinx technologies of [domains]
 (rubin-domain)=
 ### Marking up documentation with link anchors
 
-In the documentation source, we will use custom extensions (reStructuredText roles and directives) provided through [Documenteer][Documenteer] to annotate specific pages and sections as documenting a table or column.
+In the documentation source, we will use custom extensions (reStructuredText roles and directives) provided through [Documenteer][Documenteer] to annotate specific pages and sections as documenting a table or column in a data release.
 These Sphinx extensions will be part of a Rubin Observatory [Sphinx *domain*][domain].
 Sphinx domains are collections of directives that allow writers to document specific types of entities and cross reference those.
 Sphinx includes built-in domains for Python, C++, and other programming languages, which is how Sphinx API references are built.
@@ -195,7 +195,7 @@ Besides the `link` field, the response could include a `blobs` field that provid
 
 ### Structure of the entity collections API
 
-A client may need bulk access to links to a collection of entities, without needing to make a large number of HTTP requests.
+A client may need bulk access to links for a collection of entities without needing to make a large number of HTTP requests.
 For example, a client may need all columns in a table, or all tables in a data release.
 For these cases, the collections APIs can provide an array of entities and their links:
 
@@ -204,13 +204,13 @@ GET /ook/links/domain/rubin/dr/dr1/tables/visit/columns
 ```
 
 With a query string syntax, we could let the client get a subset of the collection.
-for example, all columns that start with a prefix:
+For example, all columns that start with a prefix:
 
 ```{code-block}
 GET /ook/links/domain/rubin/dr/dr1/tables/visit/columns?prefix=visit_
 ```
 
-The response includes both a data field and a separate pagination field:
+The response includes both a data object and a separate pagination object:
 
 ```{code-block} json
 {
@@ -247,7 +247,7 @@ This response schema features cursor-based pagination.
 
 #### Including child entities?
 
-Many entities in the [Rubin domain](#rubin-domain) described here are natural hierachical.
+Many entities in the [Rubin domain](#rubin-domain) described here are naturally hierachical.
 A data release contains tables, and those tables contain columns.
 It could be useful to include child entities in the response for a parent entity (essentially embedding the collections API for the child entitities in the response for the parent entity).
 If we do this, we should study how other APIs handle pagination in these types of responses.
@@ -263,7 +263,7 @@ There are two parts to the [DataLink][datalink] specification: service descripto
 
 ### Service descriptors for TAP schema documentation
 
-DataLink service descriptors annotate a result with a link endpoints that can be called by the client to get information related to the result.
+DataLink service descriptors annotate a result with metadata about link endpoints that can be called by the client to get information related to the result.
 For a TAP query result, the service descriptor would be embedded in the result's VOTable under a `RESOURCE` element with a `type="meta"` attribute.
 
 ```{note}

--- a/index.md
+++ b/index.md
@@ -13,21 +13,26 @@ With this standards-based approach, clients like the Portal can show description
 
 In this architecture, TAP tables and columns are annotated with links to Rubin documentation, such as a data release documentation site.
 This documentation is built with the [Sphinx][Sphinx]/[Documenteer][Documenteer] toolchain.
+To accomplish this, we will built upon the core Sphinx technologies of domains and Intersphinx.
 
 ### Marking up documentation with link anchors
 
 In the documentation source, we will use custom extensions (reStructuredText roles and directives) provided through [Documenteer][Documenteer] to annotate specific pages and sections as documenting a table or column.
-For example:
+These Sphinx extensions will be part of a Rubin Observatory Sphinx *domain*.
+Sphinx domains are collections of directives that allow writers to document specific types of entities and cross reference those.
+Sphinx includes built-in domains for Python, C++, and other programming languages, which is how Sphinx API references are built.
+
+An example of how a table and column might be documented in a a Sphinx project:
 
 ```{code-block} rst
 
-.. rubin-table: Visit
+.. :rubin:table: Visit
    :release: dp02_dc2_catalogs
 
 Content about the ``Visit`` table goes here
 for the DP0.2 DC2 catalogs.
 
-.. rubin-column:: physical_filter
+.. :rubin:column:: physical_filter
    :table: Visit
    :release: dp02_dc2_catalogs
 
@@ -36,34 +41,23 @@ goes here for the DP0.2 DC2 catalogs
 and ``Visit`` table.
 ```
 
-These custom directives (e.g., `rubin-table`, `rubin-column`) will leave structured hyperlink anchors in place in the generated HTML output.
-Documenteer would provide corresponding Sphinx roles that link to these anchors based on the semantics of data release, table, and column names.
+These custom directives (e.g., `:rubin:table:`, `:rubin:column:`) leave structured hyperlink anchors in the generated HTML output.
+Complementary Sphinx roles let writer cross-reference these entities in other parts of the documentation project (or even in other Sphinx projects with Intersphinx):
 
-Besides adding anchors for cross referencing, such extensions could also help to add structure and styling to the documentation, similar to how Python APIs are generated.
+```{code-block} rst
+See the :rubin:table:`Visit` table for more information.
+
+The filter for the observation is given in the :rubin:column:`physical_filter` column.
+```
 
 ### Publishing link inventories from Sphinx documentation
 
-During the Sphinx build process for a documentation site, the Documenteer Sphinx extensions will collect all documented tables and columns and generate a link inventory.
-This inventory is serialized as a structured data file (ideally JSON) and available from a well-known path relative to the documentation root (e.g. `/rubin-links.json`).
-This inventory file would be ingested by the Ook links service, which in turns would be queried by the RSP link service.
+By integrating with the Sphinx domains API, the inventory of all Rubin documentation entities, like data release tables and columns, is automatically part of the Intersphinx object inventory.
+Intersphinx publishes this inventory as a file (`objects.inv`) that is hosted alongside the HTML documentation site.
+Although the `objects.inv` format is somewhat opaque, Sphinx provides a Python API for reading it.
+We will use that API in the [Ook link service](#ook-link-service).
 
-### Integrating with Sphinx domains and intersphinx
-
-Sphinx provides two built-in mechanisms for creating custom directives and roles for cross-referencing in documentation: [domains](https://www.sphinx-doc.org/en/master/usage/domains/index.html) and [intersphinx][Intersphinx].
-
-Sphinx domains are composed of directives for defining entities and roles that reference those.
-Sphinx has built-in domains for many programming languages, and this is how Sphinx API references are built.
-For example, the Python domain has directives for defining classes, functions, and modules, and roles for referencing those.
-
-Intersphinx works with domains to provide a published object inventory (`/objects.inv`) that's typically used by other Sphinx projects to facilitate cross-referencing across projects.
-
-The custom roles and extensions mentioned above, along with the published link inventory, could also be accomplished by creating a "Rubin" domain in Sphinx.
-For providing a standards-based approach, leveraging Sphinx domains and intersphinx is a good idea.
-
-The downsides of this approach are that Sphinx domains are less flexible than a fully custom set of extensions, and the `objects.inv` format is slightly opaque without using the Sphinx Python API.
-The former could be mitigated by using the Rubin domain for linking, and creating additional custom for styling and structure.
-The later issue could be mitigated by a documentation link service, provided by Ook, described next.
-
+(ook-link-service)=
 ## The Ook link service
 
 [Ook][Ook] is an existing SQuaRE service that serves as a documentation librarian.

--- a/index.md
+++ b/index.md
@@ -1,7 +1,12 @@
-# A data documentation deep linking service with IVOA DataLink
+# Deep linking to data documentation with IVOA DataLink
 
 ```{abstract}
-LSST users retrieve data through VO services, either directly or through clients like the Rubin Science Platform's Portal. IVOA provides a DataLink specification that allows datasets to express relationships with other resources, such as related datasets. This technote outlines a method for using DataLink to also link into the documentation for data, both at the table and column level. With this standards-based approach, clients like the Portal can show descriptions and links to documentation from their user infraces.
+When presenting LSST data through VO services, we want to annotate that data with links to documentation, such as the table and column descriptions in data release documentation sites hosted on ``lsst.io``.
+This technote describes a system where we implement a linking service that uses the IVOA DataLink standard to provide links to table and column documentation.
+This link service, which resides in the Rubin Science Platform (RSP), is called by TAP schema queries.
+In turn, the link service queries Ook, Rubin Observatory's documentation metadata service that indexes the link inventories of documentation sites.
+These link inventories are prepared and included with Sphinx documentation builds using Sphinx extensions provided by the Documenteer package.
+With this standards-based approach, clients like the Portal can show descriptions and links to documentation from their user interfaces.
 ```
 
 ## Add content here

--- a/index.md
+++ b/index.md
@@ -237,7 +237,7 @@ The response includes both a data field and a separate pagination field:
     }
   ],
   "pagination": {
-    "previous": "/ook/links/domain/rubin/dr/dr1/tables/visit/columns?before=physical_filter"
+    "previous": "/ook/links/domain/rubin/dr/dr1/tables/visit/columns?before=physical_filter",
     "next": "/ook/links/domain/rubin/dr/dr1/tables/visit/columns?after=visit_id"
   }
 }
@@ -255,7 +255,43 @@ If we do this, we should study how other APIs handle pagination in these types o
 (datalinker-service)=
 ## Implementation of a VO data linking endpoint
 
-TK
+From the Rubin Science Platform, clients won't directly query the Ook link service.
+Instead, they will query a VO data linking service that uses the Ook link service as a backend.
+As a specific example [datalinker][datalinker] is a Python project that hosts data linking endpoints for the RSP for use the [DataLink][datalink] protocol.
+
+There are two parts to the [DataLink][datalink] specification: service descriptors and the link endpoints.
+
+### Service descriptors for TAP schema documentation
+
+DataLink service descriptors annotate a result with a link endpoints that can be called by the client to get information related to the result.
+For a TAP query result, the service descriptor would be embedded in the result's VOTable under a `RESOURCE` element with a `type="meta"` attribute.
+
+```{note}
+For a TAP schema query result, is this also the case?
+```
+
+For the RSP, datalink service descriptors are built from templates hosted in the [sdm_schemas][sdm_schemas] repository.
+
+```{literalinclude} service-descriptor-example.xml
+:language: xml
+```
+
+```{note}
+Questions:
+
+- What is the ID in this case?
+- What parameters can we meaningfully pass to the link endpoint? For example, can we specify a way to include all columns in a table? Can be specify a subset of columns?
+- Can the same link endpoint both describe a table itself and all its columns? Or is that two different services?
+```
+
+### Link endpoints for documentation
+
+The link endpoints, which are outlined by the service descriptors, respond with VOTables of documentation links.
+
+The link endpoints derive their data from the [Ook link service endpoints](#ook-link-service), and in fact the Ook link API generally mirrors the datalink endpoints for entity documentation links.
+The differences are that the datalink endpoint requests are authenticated with RSP credentials and that responses are VOTables.
+The VO datalink service should ideally cache responses from the Ook link service since the responses are generally stable and apply to all RSP users.
+
 
 [Sphinx]: https://www.sphinx-doc.org/
 [Documenteer]: https://documenteer.lsst.io/

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 # Deep linking to data documentation with IVOA DataLink
 
 ```{abstract}
-When presenting LSST data through VO services, we want to annotate that data with links to documentation, such as the table and column descriptions in data release documentation sites hosted on ``lsst.io``.
+When presenting LSST data through VO services, we want to annotate that data with links to documentation, such as the table and column descriptions in data release documentation sites hosted on `lsst.io`.
 This technote describes a system where we implement a linking service that uses the IVOA DataLink standard to provide links to table and column documentation.
 This link service, which resides in the Rubin Science Platform (RSP), is called by TAP schema queries.
 In turn, the link service queries Ook, Rubin Observatory's documentation metadata service that indexes the link inventories of documentation sites.
@@ -9,6 +9,61 @@ These link inventories are prepared and included with Sphinx documentation build
 With this standards-based approach, clients like the Portal can show descriptions and links to documentation from their user interfaces.
 ```
 
-## Add content here
+## Link inventories in Sphinx documentation
 
-See the [Documenteer documentation](https://documenteer.lsst.io/technotes/index.html) for tips on how to write and configure your new technote.
+In this architecture, TAP tables and columns are annotated with links to Rubin documentation, such as a data release documentation site.
+This documentation is built with the [Sphinx][Sphinx]/[Documenteer][Documenteer] toolchain.
+
+### Marking up documentation with link anchors
+
+In the documentation source, we will use custom extensions (reStructuredText roles and directives) provided through [Documenteer][Documenteer] to annotate specific pages and sections as documenting a table or column.
+For example:
+
+```{code-block} rst
+
+.. rubin-table: Visit
+   :release: dp02_dc2_catalogs
+
+Content about the ``Visit`` table goes here
+for the DP0.2 DC2 catalogs.
+
+.. rubin-column:: physical_filter
+   :table: Visit
+   :release: dp02_dc2_catalogs
+
+Content about the ``physical_filter`` column
+goes here for the DP0.2 DC2 catalogs
+and ``Visit`` table.
+```
+
+These custom directives (e.g., `rubin-table`, `rubin-column`) will leave structured hyperlink anchors in place in the generated HTML output.
+Documenteer would provide corresponding Sphinx roles that link to these anchors based on the semantics of data release, table, and column names.
+
+Besides adding anchors for cross referencing, such extensions could also help to add structure and styling to the documentation, similar to how Python APIs are generated.
+
+### Publishing link inventories from Sphinx documentation
+
+During the Sphinx build process for a documentation site, the Documenteer Sphinx extensions will collect all documented tables and columns and generate a link inventory.
+This inventory is serialized as a structured data file (ideally JSON) and available from a well-known path relative to the documentation root (e.g. `/rubin-links.json`).
+This inventory file would be ingested by the Ook links service, which in turns would be queried by the RSP link service.
+
+### Integrating with Sphinx domains and intersphinx
+
+Sphinx provides two built-in mechanisms for creating custom directives and roles for cross-referencing in documentation: [domains](https://www.sphinx-doc.org/en/master/usage/domains/index.html) and [intersphinx][Intersphinx].
+
+Sphinx domains are composed of directives for defining entities and roles that reference those.
+Sphinx has built-in domains for many programming languages, and this is how Sphinx API references are built.
+For example, the Python domain has directives for defining classes, functions, and modules, and roles for referencing those.
+
+Intersphinx works with domains to provide a published object inventory (`/objects.inv`) that's typically used by other Sphinx projects to facilitate cross-referencing across projects.
+
+The custom roles and extensions mentioned above, along with the published link inventory, could also be accomplished by creating a "Rubin" domain in Sphinx.
+For providing a standards-based approach, leveraging Sphinx domains and intersphinx is a good idea.
+
+The downsides of this approach are that Sphinx domains are less flexible than a fully custom set of extensions, and the `objects.inv` format is slightly opaque without using the Sphinx Python API.
+The former could be mitigated by using the Rubin domain for linking, and creating additional custom for styling and structure.
+The later issue could be mitigated by a documentation link service, provided by Ook, described next.
+
+[Sphinx]: https://www.sphinx-doc.org/
+[Documenteer]: https://documenteer.lsst.io/
+[Intersphinx]: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html

--- a/index.md
+++ b/index.md
@@ -22,28 +22,32 @@ The Firefly-based Portal shows information about tables and columns by making qu
 The LSST TAP schemas are annotated with [DataLink][datalink] service descriptors points to a link service, also hosted in the RSP, that provides links to entities like tables and columns in an LSST data release.
 These service descriptors are added to the TAP schema through definition files in [sdm_schemas][sdm_schemas], which is managed through [Felis][felis].
 The service descriptors specify access URLs, including query parameters, to a link endpoint provided by another RSP service.
-In the RSP, the datalinker Python project provides a link service that can be extended for this application.
-The link endpoint, through the datalinker service, operates in the RSP so that it can be aware of what data is available in that RSP, and can make any last-mile transformations to the links, including adding RSP specific links.
+In the RSP, the [datalinker][datalinker] Python project provides a link service that can be extended for this application.
+The link endpoint, through the datalinker service, operates in the RSP so that it can be aware of what data is available in that RSP, and can make any last-mile transformations to the links, including adding RSP-specific links.
+See [](#datalinker-service).
 
 [^agnostic]: Although we use the Portal as the example, and also as the driving use case, by adopting the IVOA DataLink standard, other VO clients can also get documentation links.
 
 Most documentation links will be provided through documentation sites hosted outside the Rubin Science Platform on `lsst.io`, which is managed by the LSST the Docs ({sqr}`006`) static documentation site platform.
 So that the link service in the RSP doesn't have to be aware in detail of these documentation sites, and also so that other data facilities can mix in other documentation sources for their RSP deployments, we propose that the link service also acts as a proxy to a link provider that lives closer to the documentation domain.
 
-The [Ook][ook] documentation librarian service, which is hosted in the Roundtable internal services Kubernetes cluster, already indexes documentation sites.
+The [Ook][ook] documentation librarian service, which is hosted in the Roundtable internal services Kubernetes cluster, already indexes Rubin documentation sites.
 For this application, Ook provides a new links API that provides deep links into the documentation sites for specific entities like data release data and column documentation.
+See [](#ook-link-service).
 
 To associate semantic meaning with the deep link anchors in documentation, Ook will interface specifically with the [Intersphinx][intersphinx] object inventory files that Sphinx projects publish to their `/objects.inv` paths.
 These object inventories associate hyperlink targets to all [domain][domain] entities in a Sphinx project.
 To make meaningful domain entities, we will introduce a custom [Sphinx domain][domain] for Rubin Observatory documentation to mark up data release reference documentation and related concepts.
+See [](#link-inventories).
 
-Overall this system provides a standards-based approach both for linking to documentation in with VO clients and for authoring documentation with Sphinx.
+Overall this system provides a standards-based approach both for linking to documentation with VO clients and for authoring documentation with Sphinx.
 
+(link-inventories)=
 ## Link inventories in Sphinx documentation
 
 In this architecture, TAP tables and columns are annotated with links to Rubin documentation, such as a data release documentation site.
 This documentation is built with the [Sphinx][Sphinx]/[Documenteer][Documenteer] toolchain.
-To accomplish this, we will built upon the core Sphinx technologies of [domains][domain] and [Intersphinx][intersphinx] to structure and annotate Rubin data release documentation that cross-referenceable with machine-readable link inventories.
+To accomplish this, we will build upon the core Sphinx technologies of [domains][domain] and [Intersphinx][intersphinx] to structure and annotate Rubin data release documentation that it is cross-referenceable with machine-readable link inventories.
 
 (rubin-domain)=
 ### Marking up documentation with link anchors
@@ -53,7 +57,7 @@ These Sphinx extensions will be part of a Rubin Observatory [Sphinx *domain*][do
 Sphinx domains are collections of directives that allow writers to document specific types of entities and cross reference those.
 Sphinx includes built-in domains for Python, C++, and other programming languages, which is how Sphinx API references are built.
 
-An example of how a table and column might be documented in a a Sphinx project:
+An example of how a table and column might be documented in a Sphinx project:
 
 ```{code-block} rst
 
@@ -73,12 +77,13 @@ and ``Visit`` table.
 ```
 
 These custom directives (e.g., `:rubin:table:`, `:rubin:column:`) leave structured hyperlink anchors in the generated HTML output.
-Complementary Sphinx roles let writer cross-reference these entities in other parts of the documentation project (or even in other Sphinx projects with Intersphinx):
+Complementary Sphinx roles let writers cross-reference these entities in other parts of the documentation project (or even in other Sphinx projects with [Intersphinx][intersphinx]):
 
 ```{code-block} rst
 See the :rubin:table:`Visit` table for more information.
 
-The filter for the observation is given in the :rubin:column:`physical_filter` column.
+The filter for the observation is given
+in the :rubin:column:`physical_filter` column.
 ```
 
 ### Publishing link inventories from Sphinx documentation
@@ -93,7 +98,7 @@ We will use that API in the [Ook link service](#ook-link-service).
 
 [Ook][Ook] is an existing SQuaRE service that serves as a documentation librarian.
 Ook's existing role is to index documents and populate the Algolia full-text search database that powers the Rubin Observatory documentation search at www.lsst.io.
-We propose to extend Ook to also index the link inventories (generally speaking the `objects.inv` Intersphinx inventory files and Rubin's custom link inventories if Sphinx domains aren't used).
+We propose to extend Ook to also index the link inventories (generally speaking the `objects.inv` Intersphinx inventory files).
 The Ook link service would sync these inventories into a Postgres database and then provide a REST API for querying the inventories.
 
 ```{mermaid}
@@ -247,6 +252,10 @@ A data release contains tables, and those tables contain columns.
 It could be useful to include child entities in the response for a parent entity (essentially embedding the collections API for the child entitities in the response for the parent entity).
 If we do this, we should study how other APIs handle pagination in these types of responses.
 
+(datalinker-service)=
+## Implementation of a VO data linking endpoint
+
+TK
 
 [Sphinx]: https://www.sphinx-doc.org/
 [Documenteer]: https://documenteer.lsst.io/
@@ -257,3 +266,4 @@ If we do this, we should study how other APIs handle pagination in these types o
 [domain]: https://www.sphinx-doc.org/en/master/extdev/domainapi.html
 [datalink]: https://www.ivoa.net/documents/DataLink/
 [tap]: https://www.ivoa.net/documents/TAP/
+[datalinker]: https://github.com/lsst-sqre/datalinker

--- a/overview_diagram.py
+++ b/overview_diagram.py
@@ -1,0 +1,28 @@
+import sys
+
+from diagrams import Cluster, Diagram
+from diagrams.k8s.compute import Deployment
+from diagrams.programming.language import Python
+from diagrams.saas.cdn import Fastly
+
+with Diagram("", filename=sys.argv[1], show=sys.argv[2].lower() == "true"):
+    with Cluster("Rubin Science Platform"):
+        datalinker = Deployment("datalinker")
+        portal = Deployment("portal")
+        tap = Deployment("tap")
+
+    with Cluster("Roundtable"):
+        ook = Deployment("ook")
+
+    with Cluster("lsst.io"):
+        dr1 = Fastly("dr1.lsst.io")
+
+    documenteer = Python("documenteer")
+    sdm_schemas = Python("sdm_schemas")
+
+    documenteer >> dr1
+    dr1 >> ook
+    datalinker << ook
+    sdm_schemas >> tap
+    tap >> portal
+    datalinker >> tap

--- a/service-descriptor-example.xml
+++ b/service-descriptor-example.xml
@@ -1,0 +1,20 @@
+   <RESOURCE type="meta" utype="adhoc:service" name="ColumnDocumentationLinks">
+     <DESCRIPTION>
+       This DataLlink service provides links to documentation
+       about a table's columns.
+     </DESCRIPTION>
+     <PARAM name="standardID" datatype="char" arraysize="*"
+            value="ivo://ivoa.net/std/DataLink#links-1.1" />
+     <PARAM name="accessURL" datatype="char" arraysize="*"
+            value="$baseUrl$/api/datalink/table-column-doc-links" />
+     <PARAM name="contentType" datatype="char" arraysize="*"
+            value="application/x-votable+xml;content=datalink" />
+     <PARAM name="exampleURL" datatype="char" arraysize="*"
+            value="$baseUrl$/api/datalink/table-column-doc-links?ID={table-name}&column={column-name}" />
+     <GROUP name="inputParams">
+       <PARAM name="ID" datatype="char" arraysize="*"
+              value="" ref="primaryID"/>
+       <PARAM name="column" datatype="char" arraysize="*"
+              value=""/>
+     </GROUP>
+   </RESOURCE>

--- a/technote.toml
+++ b/technote.toml
@@ -11,6 +11,7 @@ license.id = "CC-BY-4.0"
 
 [technote.status]
 state = "draft"
+note = "Architecture for the Ook link service and the Sphinx-domain based system for annotating documentation is well understood in this draft. The implemenation of a VO linking endpoint still needs design work."
 
 [[technote.authors]]
 name.given = "Jonathan"


### PR DESCRIPTION
See draft at https://sqr-086.lsst.io/v/DM-44738/index.html

This initial draft outlines my understanding of the overall achitecture for for linking to Rubin Documentation from TAP queries with DataLink. There's a firm understanding of how the links are generated and then made available to a VO link endpoint. I have a lot of gaps in my understanding of how the VO service descriptors, link endpoints, and responses would be structured.

If you have suggestions for the data link architecture I can include them in this draft, or alternatively I can merge this draft as-is and folks more knowledgeable in VO DataLink and how the portal would want to consume these links can fill in the last section.