### PR TITLE
DM-49938: Update with hoverdrive application

### DIFF
--- a/index.md
+++ b/index.md
@@ -380,13 +380,15 @@ Per typical VO conventions, the `table`[^tablenaming] and `column` names are pas
 
 [^tablenaming]: In VO, the table name is unique and therefore VO doesn't have the concept of a separate schema name, although the Rubin SDM does. Ook follows the Rubin SDM convention of a schema/table/column hierarchy, but hoverdrive presents the VO convention. Hoverdrive adapts the two conventions, knowing that in the Rubin SDM, VO tables names are formatted as `schema_name.table_name` (e.g., `dr1.Object`).
 
-```{note}
-The VO standard allows query parameter to be repeated to indicate a list of values.
-We need to check if FastAPI supports this.
+To get links in bulk, the VO standard allows query parameters to be repeated to indicate a list of values.
+For example, to get links for the `Visit` and `Object` tables:
+
+```{code-block}
+GET /api/hoverdrive/table-docs-links?table=dr1.Visit&table=dr1.Object
 ```
 
 The hoverdrive endpoints derive their data from the {ref}`Ook links API <ook-links-api>`.
-This data may be cached in the hoverdrive service to improve performance.
+These data may be cached in the hoverdrive service to improve performance.
 
 #### VOTable response
 

--- a/overview_diagram.py
+++ b/overview_diagram.py
@@ -2,12 +2,19 @@ import sys
 
 from diagrams import Cluster, Diagram
 from diagrams.k8s.compute import Deployment
+from diagrams.onprem.client import Users
 from diagrams.programming.language import Python
 from diagrams.saas.cdn import Fastly
 
-with Diagram("", filename=sys.argv[1], show=sys.argv[2].lower() == "true"):
+with Diagram(
+    "",
+    filename=sys.argv[1],
+    show=sys.argv[2].lower() == "true",
+    direction="BT",
+    curvestyle="curved",
+):
     with Cluster("Rubin Science Platform"):
-        datalinker = Deployment("datalinker")
+        hoverdrive = Deployment("hoverdrive")
         portal = Deployment("portal")
         tap = Deployment("tap")
 
@@ -22,7 +29,8 @@ with Diagram("", filename=sys.argv[1], show=sys.argv[2].lower() == "true"):
 
     documenteer >> dr1
     dr1 >> ook
-    datalinker << ook
+    hoverdrive << ook
     sdm_schemas >> tap
     tap >> portal
-    datalinker >> tap
+    hoverdrive >> tap
+    portal >> Users("Users")


### PR DESCRIPTION
We've now implemented the hoverdrive application, which replaces datalink. We also know a bit more about the implementation of the VO endpoints.