### PR TITLE
DM-50405: Update with separation of redirect and bulk links

### DIFF
--- a/service-descriptor-example.xml
+++ b/service-descriptor-example.xml
@@ -1,20 +1,40 @@
-   <RESOURCE type="meta" utype="adhoc:service" name="ColumnDocumentationLinks">
-     <DESCRIPTION>
-       This DataLink service provides links to documentation
-       about a table's columns.
-     </DESCRIPTION>
-     <PARAM name="standardID" datatype="char" arraysize="*"
-            value="ivo://ivoa.net/std/DataLink#links-1.1" />
-     <PARAM name="accessURL" datatype="char" arraysize="*"
-            value="$baseUrl$/api/datalink/table-column-doc-links" />
-     <PARAM name="contentType" datatype="char" arraysize="*"
-            value="application/x-votable+xml;content=datalink" />
-     <PARAM name="exampleURL" datatype="char" arraysize="*"
-            value="$baseUrl$/api/datalink/table-column-doc-links?ID={table-name}&column={column-name}" />
-     <GROUP name="inputParams">
-       <PARAM name="ID" datatype="char" arraysize="*"
-              value="" ref="primaryID"/>
-       <PARAM name="column" datatype="char" arraysize="*"
-              value=""/>
-     </GROUP>
-   </RESOURCE>
+<?xml version="1.0" encoding="UTF-8"?>
+<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2">
+
+  <RESOURCE type="meta" utype="adhoc:service" name="ColumnDocumentationRedirect">
+    <DESCRIPTION>
+      Redirect to the most relevant documentation link for a column.
+    </DESCRIPTION>
+    <PARAM name="accessURL" datatype="char" arraysize="*"
+          value="$baseUrl$/api/hoverdrive/column-docs-redirect"/>
+    <GROUP name="inputParams">
+      <PARAM name="table" datatype="char" use="required">
+        <DESCRIPTION>The name of the table.</DESCRIPTION>
+      </PARAM>
+      <PARAM name="column" datatype="char" arraysize="*" use="required">
+        <DESCRIPTION>The name of the column.</DESCRIPTION>
+      </PARAM>
+    </GROUP>
+    <PARAM name="exampleURL" datatype="char" arraysize="*"
+          value="$baseUrl$/api/hoverdrive/column-docs-redirect?table=dp02_dc2_catalogs.Object&amp;column=detect_isPrimary">
+      <DESCRIPTION>Example request to redirect to the documentation for the 'detect_isPrimary' column in the 'dp02_dc2_catalogs.Object' table.</DESCRIPTION>
+    </PARAM>
+  </RESOURCE>
+
+  <RESOURCE type="meta" utype="adhoc:service" name="TableDocumentationRedirect">
+    <DESCRIPTION>
+      Redirect to the most relevant documentation link for a table.
+    </DESCRIPTION>
+    <PARAM name="accessURL" datatype="char" arraysize="*"
+          value="$baseUrl$/api/hoverdrive/table-docs-redirect"/>
+    <GROUP name="inputParams">
+      <PARAM name="table" datatype="char" arraysize="*" use="required">
+        <DESCRIPTION>The name of the table.</DESCRIPTION>
+      </PARAM>
+    </GROUP>
+    <PARAM name="exampleURL" datatype="char" arraysize="*"
+          value="$baseUrl$/api/hoverdrive/table-docs-redirect?table=dp02_dc2_catalogs.Object">
+      <DESCRIPTION>Example request to redirect to the documentation for the 'dp02_dc2_catalogs.Object' table.</DESCRIPTION>
+    </PARAM>
+  </RESOURCE>
+</VOTABLE>


### PR DESCRIPTION
In https://github.com/lsst-sqre/hoverdrive/pull/5 we made the change to separate the redirect functionality in hoverdrive from the general link discovery functionality. This bypasses the change in an endpoint's behaviour based on whether a ?redirect query parameter is passed or not.